### PR TITLE
Prevent recursion depth errors on cleanup

### DIFF
--- a/Ska/ftp.py
+++ b/Ska/ftp.py
@@ -88,6 +88,10 @@ class SFTP(object):
             except:
                 pass
 
+    def close(self):
+        if hasattr(self, 'ftp') and hasattr(self.ftp, 'close'):
+            self.ftp.close()
+
     def cd(self, dirname):
         """Change to specified directory ``dirname``.
 
@@ -179,15 +183,6 @@ class SFTP(object):
         if self.logger:
             self.logger.info('Ska.ftp: rmdir {}'.format(path))
         self.ftp.rmdir(path)
-
-    def __getattr__(self, attr):
-        """
-        Fall through to SFTPClient methods, and fail if not found.
-        """
-        val = getattr(self.ftp, attr)
-        if self.logger:
-            self.logger.info('Ska.ftp: {}'.format(attr))
-        return val
 
 
 class FTP(ftplib.FTP):

--- a/Ska/ftp.py
+++ b/Ska/ftp.py
@@ -82,7 +82,10 @@ class SFTP(object):
         """
         Delete object
         """
-        self.ftp.close()
+        try:
+            self.ftp.close()
+        except:
+            pass
 
     def cd(self, dirname):
         """Change to specified directory ``dirname``.

--- a/Ska/ftp.py
+++ b/Ska/ftp.py
@@ -82,10 +82,11 @@ class SFTP(object):
         """
         Delete object
         """
-        try:
-            self.ftp.close()
-        except:
-            pass
+        if hasattr(self, 'ftp') and hasattr(self.ftp, 'close'):
+            try:
+                self.ftp.close()
+            except:
+                pass
 
     def cd(self, dirname):
         """Change to specified directory ``dirname``.

--- a/Ska/ftp.py
+++ b/Ska/ftp.py
@@ -82,11 +82,10 @@ class SFTP(object):
         """
         Delete object
         """
-        if hasattr(self, 'ftp') and hasattr(self.ftp, 'close'):
-            try:
-                self.ftp.close()
-            except:
-                pass
+        try:
+            self.close()
+        except:
+            pass
 
     def close(self):
         if hasattr(self, 'ftp') and hasattr(self.ftp, 'close'):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -64,7 +64,13 @@ def test_sftp_mkdir_rmdir_rename():
     lucky.close()
 
 
-def test_no_recursion_to_console_when_already_gone():
+def test_ftp_session_already_gone():
     lucky = Ska.ftp.SFTP('lucky', logger=logger)
+    # explicitly close paramiko channel, socket, and session
+    lucky.ftp.sock.get_transport().close()
+    lucky.ftp.sock.close()
+    lucky.ftp.close()
+    # delete ftp session
     del lucky.ftp
+    # explicitly run __del__ method
     lucky.__del__()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -62,3 +62,9 @@ def test_sftp_mkdir_rmdir_rename():
     lucky.rmdir(new)
 
     lucky.close()
+
+
+def test_no_recursion_to_console_when_already_gone():
+    lucky = Ska.ftp.SFTP('lucky', logger=logger)
+    del lucky.ftp
+    lucky.__del__()


### PR DESCRIPTION
This fixes recursion errors if self.ftp no longer exists to close.