### PR TITLE
Restore 'Ska' to package list for namespace packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='Ska.ftp',
       url='http://cxc.harvard.edu/mta/ASPECT/tool_doc/pydocs/Ska.ftp.html',
       version=__version__,
       zip_safe=False,
-      packages=['Ska.ftp', 'Ska.ftp.tests'],
+      packages=['Ska', 'Ska.ftp', 'Ska.ftp.tests'],
       tests_require=['pytest'],
       cmdclass=cmdclass,
       )


### PR DESCRIPTION
It was a mistake in #7 to remove `'Ska'` from the package list instead of adding `Ska.ftp`.  I did initially test by installing to `--user` but for some reason this worked, while installing via skare resulted in a weird mess.