### PR TITLE
Python 3 compatibility

### DIFF
--- a/Ska/ftp/__init__.py
+++ b/Ska/ftp/__init__.py
@@ -1,6 +1,6 @@
 from .ftp import *
 
-__version__ = '0.4.2'
+__version__ = '0.4.3'
 
 
 def test(*args, **kwargs):

--- a/Ska/ftp/tests/test_basic.py
+++ b/Ska/ftp/tests/test_basic.py
@@ -78,7 +78,7 @@ def test_delete_when_ftp_session_already_gone(capfd):
     # If Ska.ftp this hasn't been fixed to
     # avoid attribute recursion when deleting the Ska.ftp object
     # this prevents a failed test from taking a very long time.
-    sys.setrecursionlimit(100)
+    sys.setrecursionlimit(200)
     # And then delete the object.
     # The missing ftp attribute should raise an AttributeError, but it
     # is printed to stderr by __del__ instead of being raised

--- a/Ska/ftp/tests/test_tar.py
+++ b/Ska/ftp/tests/test_tar.py
@@ -1,8 +1,8 @@
 import os
 import Ska.ftp
 import tarfile
-import cPickle as pickle
-from cStringIO import StringIO
+from six.moves import cPickle as pickle
+from six.moves import cStringIO as StringIO
 
 import pytest
 


### PR DESCRIPTION
Interesting error that forced changed recursion limit from 100 to 200:
```
capfd = <_pytest.capture.CaptureFixture object at 0x7f1aca3209b0>

    def test_delete_when_ftp_session_already_gone(capfd):
        """
        Confirm that Ska.ftp does not end up with a recursive delete if the
        paramiko ftp instance is removed before the Ska.ftp object is deleted
        """
        lucky = Ska.ftp.SFTP('lucky', logger=logger)
        # Delete the paramiko session (without explicitly closing in this test case)
        del lucky.ftp
        # Set the recursion limit
        # If Ska.ftp this hasn't been fixed to
        # avoid attribute recursion when deleting the Ska.ftp object
        # this prevents a failed test from taking a very long time.
>       sys.setrecursionlimit(100)
E       RecursionError: cannot set the recursion limit to 100 at the recursion depth 84: the limit is too low

test_basic.py:81: RecursionError
```
