### PR TITLE
Wrap attempt to close ftp session on __del__ in try/catch

### DIFF
--- a/Ska/ftp/ftp.py
+++ b/Ska/ftp/ftp.py
@@ -80,7 +80,10 @@ class SFTP(object):
         """
         Delete object
         """
-        self.ftp.close()
+        try:
+            self.ftp.close()
+        except:
+            pass
 
     def cd(self, dirname):
         """Change to specified directory ``dirname``.


### PR DESCRIPTION
self.ftp.close() seems to throw an exception if the session is gone. Exceptions are ignored in __del__ anyway, but this can end up printed to console (and, for example, ends up in the kadi test output, and I
don't see a problem with the kadi test setup).

```
Do you really want to exit ([y]/n)? y
Exception TypeError: 'must be type, not None' in <bound method SFTP.__del__ of <Ska.ftp.ftp.SFTP object at 0x7f5379cc6e50>> ignored
```