### PR TITLE
Wrap attempt to close ftp session on __del__ in try/catch

### DIFF
--- a/Ska/ftp/ftp.py
+++ b/Ska/ftp/ftp.py
@@ -81,7 +81,10 @@ class SFTP(object):
         """
         Delete object
         """
-        self.ftp.close()
+        try:
+            self.ftp.close()
+        except:
+            pass
 
     def cd(self, dirname):
         """Change to specified directory ``dirname``.

--- a/Ska/ftp/ftp.py
+++ b/Ska/ftp/ftp.py
@@ -79,8 +79,14 @@ class SFTP(object):
 
     def __del__(self):
         """
-        Delete object
+        Try to close object as part of delete
         """
+
+        # Make attempt to close an open session as part of __del__ cleanup.
+        # Handle this with a non-specific try/except in this case as we don't
+        # care about errors closing on cleanup, especially if the object is
+        # already gone.  Exceptions are ignored in __del__ anyway, but can be
+        # printed to console (which can cause errors for test checking)
         try:
             self.ftp.close()
         except:

--- a/Ska/ftp/tests/test_basic.py
+++ b/Ska/ftp/tests/test_basic.py
@@ -70,13 +70,13 @@ def test_sftp_mkdir_rmdir_rename():
 
 def test_delete_when_ftp_session_already_gone(capfd):
     """
-    Confirm that Ska.ftp does not end up with a recursive delete if the
-    paramiko ftp instance is removed before the Ska.ftp object is deleted
+    Confirm that Ska.ftp does not throw attribute errors when deleted.
     """
     lucky = Ska.ftp.SFTP('lucky', logger=logger)
     # Delete the paramiko session (without explicitly closing in this test case)
     del lucky.ftp
     del lucky
+    # Should see no errors in stderr when deleting the lucky object
     out, err = capfd.readouterr()
     assert err == ''
 

--- a/Ska/ftp/tests/test_basic.py
+++ b/Ska/ftp/tests/test_basic.py
@@ -76,17 +76,9 @@ def test_delete_when_ftp_session_already_gone(capfd):
     lucky = Ska.ftp.SFTP('lucky', logger=logger)
     # Delete the paramiko session (without explicitly closing in this test case)
     del lucky.ftp
-    # Set the recursion limit
-    # If Ska.ftp this hasn't been fixed to
-    # avoid attribute recursion when deleting the Ska.ftp object
-    # this prevents a failed test from taking a very long time.
-    sys.setrecursionlimit(200)
-    # And then delete the object.
-    # The missing ftp attribute should raise an AttributeError, but it
-    # is printed to stderr by __del__ instead of being raised
     del lucky
     out, err = capfd.readouterr()
-    assert re.search('attr missing from Ska.ftp object', err) is not None
+    assert err == ''
 
 
 def test_parse_netrc():


### PR DESCRIPTION
self.ftp.close() seems to throw an exception if the session is gone.
Exceptions are ignored in `__del__` anyway, but this can end up printed
to console (and, for example, ends up in the kadi test output, and I
don't see a problem with the kadi test setup).

This is a reboot of #12 which I merged and then reverted when I got around to testing on Python 3.6 and saw unexpected errors.  I'll redo that testing (and fix as needed) before merging this again.